### PR TITLE
Update version to 0.3.0 and refine dependency constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "up-bank-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SDK for the Up Bank API"
 readme = "README.md"
 license = "MIT"
@@ -24,10 +24,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "requests>=2.31.0",
-    "pydantic>=2.0.0",
-    "tenacity>=8.0.0",
-    "httpx>=0.27.0",
+    "requests>=2.31.0,<3.0.0",
+    "pydantic>=2.0.0,<3.0.0",
+    "tenacity>=8.0.0,<9.0.0",
+    "httpx>=0.27.0,<1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,6 @@ class TestConfig:
         assert config.retry_wait_multiplier == 1.0
         assert config.retry_wait_min == 2.0
         assert config.retry_wait_max == 30.0
-        assert config.retry_on_status == (429, 500, 502, 503, 504)
 
     def test_custom_values(self) -> None:
         """Test custom configuration values."""

--- a/up_bank_sdk/__init__.py
+++ b/up_bank_sdk/__init__.py
@@ -1,6 +1,6 @@
 """Up Bank SDK - Python SDK for the Up Bank API."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 
 from up_bank_sdk.async_client import AsyncClient
 from up_bank_sdk.client import Client

--- a/up_bank_sdk/config.py
+++ b/up_bank_sdk/config.py
@@ -15,4 +15,3 @@ class Config:
     retry_wait_multiplier: float = 1.0
     retry_wait_min: float = 2.0
     retry_wait_max: float = 30.0
-    retry_on_status: tuple[int, ...] = (429, 500, 502, 503, 504)


### PR DESCRIPTION
Bump the version of the Up Bank SDK to 0.3.0 and adjust dependency constraints to ensure compatibility with future releases. Remove the retry_on_status configuration from the defaults.